### PR TITLE
Add Belarusian i18n

### DIFF
--- a/src/i18n/be-BY.js
+++ b/src/i18n/be-BY.js
@@ -1,0 +1,94 @@
+/**
+ * SVGcode—Convert raster images to SVG vector graphics
+ * Copyright (C) 2022 Google LLC
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import languages from './languages.js';
+
+const translations = {
+  red: 'Чырвоны',
+  green: 'Зялёны',
+  blue: 'Блакітны',
+  alpha: 'Празрыстасць',
+
+  brightness: 'Яркасць',
+  contrast: 'Кантраст',
+  grayscale: 'Манахром',
+  'hue-rotate': 'Паварот колеру',
+  invert: 'Інверсія',
+  opacity: 'Празрыстасць',
+  saturate: 'Насычэнне',
+  sepia: 'Сепія',
+
+  scale: 'Маштаб',
+  rotation: 'Паварот',
+  turdsize: 'Паменшыць смецце',
+  alphamax: 'Кутні парог',
+  minPathSegments: 'Мінімальная даўжыня шляху',
+  strokeWidth: 'Таўшчыня абводкі',
+  turnpolicy: 'Правілы павароту',
+  opticurve: 'Аптымізаваць крывыя',
+  opttolerance: 'Узровень аптымізацыі',
+  showAdvancedControls: 'Дадатковыя налады',
+
+  '%': '%',
+  deg: '°',
+  steps: 'крокаў',
+  pixels: 'пікселяў',
+  segments: 'сегментаў',
+
+  reset: 'Скінуць',
+  resetAll: 'Скінуць усё',
+
+  dropFileHere: 'Кіньце файл сюды',
+  openImage: 'Адкрыць карцінку',
+  saveSVG: 'Захаваць SVG',
+  pasteImage: 'Уставіць карцінку',
+  copySVG: 'Скапіяваць SVG',
+  install: 'Усталяваць',
+
+  posterizeInputImage: 'Пастэрызаваць ўваходную карцінку',
+  colorSVG: 'Каляровы SVG',
+  monochromeSVG: 'Манахромны SVG',
+
+  colorChannels: 'Каляровыя каналы',
+  imageSizeAndRotation: 'Ўваходныя памеры і паварот',
+  imagePreprocessing: 'Уваходная апрацоўка',
+  svgOptions: 'Налады SVG',
+
+  considerDPR: 'Ўлічваць шчыльнасць пікселяў',
+
+  tweak: 'Падкруціць',
+  closeOptions: 'Закрыць',
+
+  optimizingSVG: 'Аптымізую SVG',
+  copiedSVG: 'Скапіяваны SVG',
+  savedSVG: 'Захаваны SVG',
+
+  readyToWorkOffline: 'Гатова для працы афлайн.',
+  svgSize: 'Памер SVG',
+  bytes: 'байтаў',
+  zoom: 'Маштаб',
+
+  license: 'Ліцэнзія',
+  about: 'Аб праекце',
+
+  ...languages,
+};
+
+// ignore unused exports default
+export default translations;

--- a/src/i18n/languages.js
+++ b/src/i18n/languages.js
@@ -19,6 +19,7 @@
 
 const languages = {
   arTN: 'عربى',
+  beBY: 'Беларуская',
   caES: 'Català',
   daDK: 'Dansk',
   deDE: 'Deutsch',

--- a/src/js/i18n.js
+++ b/src/js/i18n.js
@@ -20,6 +20,7 @@
 const LOCAL_STORAGE_KEY = 'language';
 const SUPPORTED_LANGUAGES = [
   'ar',
+  'be',
   'ca',
   'da',
   'de',
@@ -43,6 +44,7 @@ const SUPPORTED_LANGUAGES = [
 
 const SUPPORTED_LOCALES = [
   'ar-TN',
+  'be-BY',
   'ca-ES',
   'da-DK',
   'de-DE',


### PR DESCRIPTION
Based on https://github.com/tomayac/SVGcode/pull/60.

Has the same problems as Vadim mentioned there:
> Some words needs to be inflected for proper grammar: 1 шаг, 2 шага, 5 шагов (1, 2, 5 steps). There is a lazy way of solving this: шаги: 1, 2, 5 (steps: 1, 2, 5), but requires some changes in templates too. Who knows, maybe there’s something in [Intl.PluralRules()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/PluralRules/PluralRules) that might help.`