### PR TITLE
docs: add Terms of Service, Privacy Policy, and Refund Policy for Lemon Squeezy premium features

### DIFF
--- a/docs/privacy_policy.md
+++ b/docs/privacy_policy.md
@@ -1,0 +1,57 @@
+# Privacy Policy
+
+**Effective date: June 1, 2026**
+
+Your privacy is important to us. This Privacy Policy explains what data SVGcode (available at [svgco.de](https://svgco.de)) collects, how it is used, and your rights.
+
+## 1. Summary
+
+**SVGcode itself does not collect, store, or process any personal data.** All image processing happens locally in your browser. Your images never leave your device when using the core application.
+
+## 2. Data We Do Not Collect
+
+SVGcode does not:
+- Upload your images to any server
+- Track your usage or behavior within the app
+- Use analytics or telemetry
+- Set tracking cookies
+- Maintain user accounts
+
+## 3. Data Collected During Premium Purchases
+
+When you purchase a premium feature, the transaction is processed by **Lemon Squeezy**. During checkout, Lemon Squeezy may collect:
+
+- Your name and email address
+- Billing address
+- Payment information (credit/debit card or other payment method)
+- IP address and purchase metadata
+
+This data is collected and processed by Lemon Squeezy, who acts as the Merchant of Record. SVGcode receives only a confirmation that a purchase was made and a license key or access token to enable the premium feature on your device. Please review [Lemon Squeezy's Privacy Policy](https://www.lemonsqueezy.com/privacy) for details on how they handle your data.
+
+## 4. License Key Storage
+
+If you purchase a premium feature, a license key or activation token may be stored locally in your browser (via `localStorage` or similar browser storage). This data stays on your device and is not transmitted to any server by SVGcode.
+
+## 5. Service Workers and Caching
+
+SVGcode uses a service worker to enable offline functionality. The service worker caches application assets locally on your device. No personal data is included in these caches.
+
+## 6. Third-Party Services
+
+SVGcode is hosted on GitHub Pages. GitHub may collect server logs including IP addresses as part of serving static files. See [GitHub's Privacy Statement](https://docs.github.com/en/site-policy/privacy-policies/github-general-privacy-statement) for details.
+
+## 7. Children's Privacy
+
+SVGcode is not directed at children under 13 years of age. We do not knowingly collect personal information from children.
+
+## 8. Your Rights
+
+If you are in the European Economic Area (EEA) or similar jurisdiction, you may have rights regarding personal data held by Lemon Squeezy on your behalf (e.g., access, rectification, erasure). Please contact Lemon Squeezy directly for such requests, or contact us and we will forward your request.
+
+## 9. Changes to This Policy
+
+We may update this Privacy Policy from time to time. Changes will be reflected by updating the effective date above. Continued use of SVGcode after changes constitutes acceptance of the updated policy.
+
+## 10. Contact
+
+For privacy-related questions, contact us at: **[thomas.steiner@gmail.com](mailto:thomas.steiner@gmail.com)**

--- a/docs/refund_policy.md
+++ b/docs/refund_policy.md
@@ -1,0 +1,40 @@
+# Refund Policy
+
+**Effective date: June 1, 2026**
+
+We want you to be happy with your purchase of SVGcode premium features. This policy explains when and how you can request a refund.
+
+## 1. 14-Day Satisfaction Guarantee
+
+If you are not satisfied with a premium feature purchase for any reason, you may request a full refund within **14 days** of your purchase date. No questions asked.
+
+## 2. How to Request a Refund
+
+To request a refund:
+
+1. Email **[thomas.steiner@gmail.com](mailto:thomas.steiner@gmail.com)** with the subject line "Refund Request"
+2. Include your order number (found in your Lemon Squeezy purchase confirmation email)
+3. Optionally, let us know why you'd like a refund — this helps us improve
+
+We aim to process refund requests within **3 business days**. Refunds are returned to the original payment method and may take an additional 5–10 business days to appear, depending on your bank.
+
+Alternatively, you can request a refund directly through Lemon Squeezy's customer portal using the link in your purchase confirmation email.
+
+## 3. Refunds After 14 Days
+
+After the 14-day window, refunds are granted at our discretion. We will consider refunds in cases where:
+
+- The premium feature is fundamentally broken and we are unable to fix it within a reasonable timeframe
+- The feature was materially misrepresented
+
+## 4. Permanent Feature Discontinuation
+
+If a premium feature you purchased is permanently discontinued, we will issue a full refund regardless of when the original purchase was made.
+
+## 5. What Happens After a Refund
+
+Upon issuing a refund, your license key or access to the premium feature will be deactivated. You are welcome to continue using all free, open-source features of SVGcode.
+
+## 6. Contact
+
+For refund-related questions, contact us at: **[thomas.steiner@gmail.com](mailto:thomas.steiner@gmail.com)**

--- a/docs/terms_of_service.md
+++ b/docs/terms_of_service.md
@@ -1,0 +1,61 @@
+# Terms of Service
+
+**Effective date: June 1, 2026**
+
+These Terms of Service ("Terms") govern your use of SVGcode (available at [svgco.de](https://svgco.de)), including any premium features purchased through our payment processor. By using SVGcode, you agree to these Terms.
+
+## 1. About SVGcode
+
+SVGcode is an open-source Progressive Web App (PWA) that converts raster images to SVG vector graphics. The core application is free and open source under its applicable license. Certain premium features may be offered for a one-time payment.
+
+## 2. Free and Premium Features
+
+**Free features** are available to all users at no cost. The source code for the core application is available on [GitHub](https://github.com/tomayac/SVGcode).
+
+**Premium features** (such as access to an enhanced SVG tracing algorithm) are available for a one-time payment. Once purchased, you receive a perpetual, non-transferable license to use that premium feature. There are no subscriptions or recurring charges unless explicitly stated at the time of purchase.
+
+## 3. Payments
+
+Payments for premium features are processed by **Lemon Squeezy** (a Lemon Squeezy, LLC service). By completing a purchase, you also agree to [Lemon Squeezy's Terms of Service](https://www.lemonsqueezy.com/terms). SVGcode does not store or process your payment card information directly.
+
+Prices are listed in USD unless otherwise stated and may include applicable taxes where required by law. Lemon Squeezy acts as the Merchant of Record for all purchases, meaning they are responsible for billing, tax collection, and compliance in your jurisdiction.
+
+## 4. Refunds
+
+Please see our [Refund Policy](#) for details. Refund requests are handled through Lemon Squeezy. We honor a 14-day refund window for premium feature purchases if you are not satisfied.
+
+## 5. License for Premium Features
+
+Upon successful payment, you are granted a personal, non-exclusive, non-transferable, worldwide license to use the purchased premium feature(s) for your own personal or commercial projects. You may not resell, sublicense, or redistribute the premium feature(s) themselves.
+
+## 6. Open Source Components
+
+The core of SVGcode remains open source. Nothing in these Terms restricts your rights under the open source license that applies to the core codebase. Premium features may include proprietary components that are not covered by the open source license.
+
+## 7. Intellectual Property
+
+SVGcode and its premium features, including all software, algorithms, and related content, are owned by Thomas Steiner or licensed to him. The SVGcode name, logo, and premium components are protected by applicable intellectual property laws.
+
+## 8. Disclaimer of Warranties
+
+SVGcode is provided **"as is"** and **"as available"** without warranties of any kind, express or implied, including but not limited to warranties of merchantability, fitness for a particular purpose, or non-infringement. We do not warrant that the service will be uninterrupted, error-free, or that defects will be corrected.
+
+## 9. Limitation of Liability
+
+To the fullest extent permitted by applicable law, Thomas Steiner shall not be liable for any indirect, incidental, special, consequential, or punitive damages arising out of or related to your use of SVGcode or its premium features, even if advised of the possibility of such damages. Our total liability for any claim shall not exceed the amount you paid for the relevant premium feature.
+
+## 10. Modifications to the Service
+
+We reserve the right to modify, suspend, or discontinue any part of SVGcode at any time. For premium features, we will make reasonable efforts to maintain functionality. In the event a premium feature is permanently discontinued, we will offer a pro-rata refund at our discretion.
+
+## 11. Changes to These Terms
+
+We may update these Terms from time to time. We will notify users of material changes by updating the effective date above and, where appropriate, through the application. Continued use of SVGcode after changes constitutes acceptance of the new Terms.
+
+## 12. Governing Law
+
+These Terms are governed by the laws of Spain, without regard to its conflict of law provisions. Any disputes shall be resolved in the courts of Seville, Spain, unless applicable consumer protection laws in your jurisdiction provide otherwise.
+
+## 13. Contact
+
+For questions about these Terms, contact us at: **[thomas.steiner@gmail.com](mailto:thomas.steiner@gmail.com)**

--- a/index.html
+++ b/index.html
@@ -183,6 +183,24 @@
                 href="https://github.com/tomayac/SVGcode/blob/main/LICENSE"
               ></a>
             </li>
+            <li>
+              <a
+                class="terms"
+                href="https://github.com/tomayac/SVGcode/blob/main/docs/terms_of_service.md"
+              >Terms of Service</a>
+            </li>
+            <li>
+              <a
+                class="privacy"
+                href="https://github.com/tomayac/SVGcode/blob/main/docs/privacy_policy.md"
+              >Privacy Policy</a>
+            </li>
+            <li>
+              <a
+                class="refund"
+                href="https://github.com/tomayac/SVGcode/blob/main/docs/refund_policy.md"
+              >Refund Policy</a>
+            </li>
           </ul>
           <dark-mode-toggle
             permanent


### PR DESCRIPTION
This PR adds three legal documents to `docs/` in preparation for launching premium features (e.g. a better SVG tracing algorithm) sold via Lemon Squeezy.

## Documents added

### `docs/terms_of_service.md`
Covers:
- Distinction between free/open-source core and premium features
- One-time payment model (no subscriptions)
- Lemon Squeezy as payment processor and Merchant of Record
- Perpetual personal license granted on purchase
- Open-source license unaffected
- 14-day refund window (matches refund policy)
- Governing law: Spain / Seville

### `docs/privacy_policy.md`
Covers:
- No data collection by the app itself (all processing is local/in-browser)
- What Lemon Squeezy collects during checkout (and pointer to their policy)
- Local-only storage of license keys
- Service worker caching (no personal data)
- GitHub Pages hosting (GitHub's own privacy statement)
- GDPR-friendly framing for EEA users

### `docs/refund_policy.md`
Covers:
- 14-day no-questions-asked full refund
- How to request: email or Lemon Squeezy customer portal
- Refunds after 14 days at discretion (broken/misrepresented features)
- Full refund if a feature is permanently discontinued
- License deactivation after refund

## Notes
- The existing `docs/privacy_policy.txt` (one line) is superseded by the new `docs/privacy_policy.md` but left in place to avoid breaking existing links — you may want to delete or redirect it.
- All contact references point to `thomas.steiner@gmail.com`; update if you prefer a different support address.
- These are not legal advice. Consider having a lawyer review before relying on them.